### PR TITLE
AD-1229 SNS.2 Playbook has a invalid runbook ASR-EnableDeliveryLoggingForSNSTopic

### DIFF
--- a/source/playbooks/SC/ssmdocs/SC_SNS.2.ts
+++ b/source/playbooks/SC/ssmdocs/SC_SNS.2.ts
@@ -6,10 +6,10 @@ import { PlaybookProps } from '../lib/control_runbooks-construct';
 import { HardCodedString, Input, StringVariable } from '@cdklabs/cdk-ssm-documents';
 
 export function createControlRunbook(scope: Construct, id: string, props: PlaybookProps): ControlRunbookDocument {
-  return new EnableDeliveryLoggingForSNSTopicDocument(scope, id, { ...props, controlId: 'SNS.2' });
+  return new EnableDeliveryStatusLoggingForSNSTopicDocument(scope, id, { ...props, controlId: 'SNS.2' });
 }
 
-export class EnableDeliveryLoggingForSNSTopicDocument extends ControlRunbookDocument {
+export class EnableDeliveryStatusLoggingForSNSTopicDocument extends ControlRunbookDocument {
   constructor(scope: Construct, id: string, props: ControlRunbookProps) {
     const docInputs = [
       Input.ofTypeString('LoggingRole', {
@@ -22,7 +22,7 @@ export class EnableDeliveryLoggingForSNSTopicDocument extends ControlRunbookDocu
       ...props,
       docInputs,
       securityControlId: 'SNS.2',
-      remediationName: 'EnableDeliveryLoggingForSNSTopic',
+      remediationName: 'EnableDeliveryStatusLoggingForSNSTopic',
       scope: RemediationScope.REGIONAL,
       resourceIdName: 'SNSTopicArn',
       updateDescription: HardCodedString.of('Delivery Status Logging enabled on SNS Topic'),


### PR DESCRIPTION
*Issue #, if available:*
SNS.2 Playbook has a invalid runbook name EnableDeliveryLoggingForSNSTopic

*Description of changes:*
EnableDeliveryLoggingForSNSTopic was renamed to EnableDeliveryStatusLoggingForSNSTopic in the SC_SNS.2.ts file.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.