### PR TITLE
AD-1230 Fix typo for SNS.1 where TopicArn should be SNSTopicArn

### DIFF
--- a/source/playbooks/AFSBP/ssmdocs/AFSBP_SNS.1.yaml
+++ b/source/playbooks/AFSBP/ssmdocs/AFSBP_SNS.1.yaml
@@ -84,7 +84,7 @@ mainSteps:
       RuntimeParameters:
         KmsKeyArn: '{{KmsKeyArn}}'
         AutomationAssumeRole: 'arn:{{global:AWS_PARTITION}}:iam::{{global:ACCOUNT_ID}}:role/SO0111-EnableEncryptionForSNSTopic'
-        TopicArn: '{{ParseInput.SNSTopicArn}}'
+        SNSTopicArn: '{{ParseInput.SNSTopicArn}}'
 
   - name: UpdateFinding
     action: 'aws:executeAwsApi'

--- a/source/remediation_runbooks/EnableEncryptionForSNSTopic.yaml
+++ b/source/remediation_runbooks/EnableEncryptionForSNSTopic.yaml
@@ -32,7 +32,7 @@ parameters:
       {{ssm:/Solutions/SO0111/CMK_REMEDIATION_ARN}}
     description: The ARN of the KMS key created by ASR for this remediation
     allowedPattern: '^arn:(?:aws|aws-us-gov|aws-cn):kms:(?:[a-z]{2}(?:-gov)?-[a-z]+-\d):\d{12}:(?:(?:alias/[A-Za-z0-9/-_])|(?:key/(?i:[0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12})))$'
-  TopicArn:
+  SNSTopicArn:
     type: String
     description: (Required) The ARN of the Amazon SNS Topic.
     allowedPattern: '^arn:(?:aws|aws-us-gov|aws-cn):sns:(?:[a-z]{2}(?:-gov)?-[a-z]+-\d):\d{12}:([a-zA-Z0-9_-]{1,80}(?:\.fifo)?)$'
@@ -53,7 +53,7 @@ mainSteps:
     inputs:
       Service: sns
       Api: SetTopicAttributes
-      TopicArn: "{{TopicArn}}"
+      TopicArn: "{{SNSTopicArn}}"
       AttributeName: KmsMasterKeyId
       AttributeValue: "{{KmsKeyArn}}"
     outputs:


### PR DESCRIPTION
*Issue #, if available:*
bugfix for name change for parameter name TopicArn to SNSTopicArn

*Description of changes:*
Fix typo for SNS.1 where TopicArn should be SNSTopicArn

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.